### PR TITLE
add missing meeting notes

### DIFF
--- a/meetings/archive/20200721_agenda_and_minutes.md
+++ b/meetings/archive/20200721_agenda_and_minutes.md
@@ -1,0 +1,115 @@
+# Conda-Tools Kick-off Agenda
+
+1. Brief Intros
+    who's here?
+     - Amy Williams
+     - Angela Gloyna
+     - Anthony Scopatz
+     - Cheng Lee
+     - Connor Martin
+     - Crystal Soja
+     - Eric Dill
+     - Filipe Fernandes
+     - John Kirkham
+     - Jonathan Helmus
+     - Johan Mabille
+     - Kai Tietz
+     - Keith Kraus
+     - Marcel Bargull
+     - Marcelo Trevisani
+     - Marius van Niekerk
+     - Matthew Becker
+     - Megan Yancy
+     - Michael Sarahan
+     - Patrick Sodré
+     - Peter Wang
+     - Ray Donnelly
+     - Raymond Douglass
+     - Sebastien Awwad
+     - Sylvain Corlay
+     - Tadeu Manoel
+     - Travis Oliphant
+     - Uwe Korn
+     - Wolf Vollprecht
+     - Yuvi Panda
+3. Goals 
+    * NumFOCUS Sponsorship
+    * Conda Specs
+    * A place for tools to live 
+    * Support for tools
+    * Open Roadmap
+    * 
+4. Contributions
+5. Agenda
+    * Introductions
+    * Goals - Set up new organization to
+        *  Discuss conda and ecosystem specifications
+        *  Put toolings in a common location
+        *  Provide governance
+    * Name?
+        * conda-tools org (https://github.com/conda-tools) : currently owned by conda-forge
+        * conda org (https://github.com/conda) : owned by Anaconda, Inc
+            * Preferred by Peter
+            * Has existed for considerable time
+            * Community would need to take admin control over the org
+                * Move conda, conda-build, etc out?
+            * Phased "transition"
+                * 1. Move tools to conda organization (separate governance models for projects initially)
+                * 2. Common governance model for tools, especially conda, eventually, hopefully, maybe...
+            * What is the criteria for a project to be included in the conda organization
+                * Balance easy to include in org with stability
+                * Developing outside of the org allows easier freedom to explore
+                * Incubator organization or "tag"
+                    * org seems better
+                    * incubator has not worked well in Jupyter, JEPs are needed for electing projects to the core org. 
+                        * Incubation process rarely used
+                        * Projects tend to be developed "out in the world" and added directly to Jupyter without incubation
+                * When a project is moved to "core", there is a maintainance burden.  Incubating projects are more experimental
+                * Moving to a incubating org allows projects to continue when developers leave companies.  
+                    * Critia for inclusion should be minimal
+                    * Automated process
+        * SnakePit (https://github.com/TheSnakePit): QuantStack lead (mamba, boa, quetz)
+        * Other random name
+            * Can the conda name be used?
+                * Peter + Travis are okay with use and do not major concerns
+                * Peter has concern about non-participants hijacking (strip mining) the community
+                * How do we protect ourselves from these type of actions?
+                    * Form a consortium 
+                * mamba, boa and quetz do not use "conda" to avoid trademark infringement
+                    * Might change if there were rules for using the conda name 
+                * Papertrail giving conda-forge and other communities permission to use the conda "name"
+            * bioconda related?
+    * Specifications
+        * Compatibility vs Maintainance
+        * Would like to see a voting aspect to specification
+        * Roadmap for specs
+    * Support
+        * In phase one, support would be provided by the projects themselves
+        * 
+7. Governance
+    * Proposal: Use conda-forge governance doc for this, modify for use case
+    * core group is ~folks on this call
+    * Commit rights should be maintained as projects move to new organizations
+    * Initially individual projects would retain their own governance but be under the conda organization
+    * Bootstrapping voting body
+        * allow ppl to sign up, you have to vote to be in
+    * README should include who runs them (Anaconda, QuantStack, individuals).  Should include information on what level of support is provided and how to ask for it 
+9. What should we call ourselves?
+    * Can we use the conda org?
+    * Respecting the conda trademark 
+        * [scopatz] - I think uses such as in conda-forge or conda-lock  fall under fair use as long as we don't then go and and try to trademark those conda-forge itself: https://en.wikipedia.org/wiki/Fair_use_(U.S._trademark_law)
+
+
+# Other notes / discussions
+* Where to have ongoing conversations? 
+    * New slack org? Slack channel on existing slack workspace?
+    * maybe gitter?
+
+
+# Next Steps
+* How do we continue the conversions
+    * https://github.com/conda-incubator (yay!)
+    * Slack!
+    * https://join.slack.com/t/conda-tools/shared_invite/zt-g0907dnm-FgXZrDkZ3WdcTNhg6d3ffQ
+    * weekly or fortnightly call to keep things moving
+    

--- a/meetings/archive/20201020_agenda_and_minutes.md
+++ b/meetings/archive/20201020_agenda_and_minutes.md
@@ -1,0 +1,141 @@
+# 2020-10-20 Conda Community Meeting
+
+****
+
+[Meeting link](https://meet.google.com/owq-kbca-abk)
+
+[What time is the meeting in my time zone](https://arewemeetingyet.com/Chicago/2020-10-20/09:00/b/Conda%20community%20meeting)
+
+[Last Meeting's Agenda and Minutes](https://github.com/conda-incubator/governance/tree/master/meetings)
+
+## Attendees
+
+* **Name (Initials) (githubid)**
+* Matthew R Becker (MRB) (beckermr)
+* Megan C. Yancy (MCY) myancy-anaconda
+* Michael C. Grant (MCG) mcg1969
+* Paul Ivanov (PI) ivanov
+* Michael Sarahan (MCS)
+* Cheng Lee (CHL) (chenghlee)
+* Hameer Abbasi (HA) (hameerabbasi)
+* Amy Williams (AW) (@awilliams-anaconda)
+* Kale Franz (KF) @kalefranz
+* Sebastien Awwad (SA) (awwad)
+* Marcel Bargull (MB) mbargull
+* Crystal Soja (CAS)
+* Uwe Korn (UK) (xhochy)
+* Filipe Fernandes (FF)
+* Marcelo Duarte Trevisani (MDT) (marcelotrevisani)
+* Connor Martin (CJM)
+* Gonzalo Peña-Castellanos (GPC)
+* Eric Dill (EDD) gh: ericdill
+* Peter Wang (PZW)
+* Scopatz (SPZ)
+
+## Agenda
+
+* Welcome
+
+### Announcements
+* Meeting for 20201103: Move to 20201102 (Election day is 20201103)
+
+### Standing Items
+
+* Website: Check the draft for [text on the website](https://docs.google.com/document/d/1gECzDW4QluEM2-00xrxoseKLD2MaD9k_xvcwj3cxtMg/edit#heading=h.j4l7zepliw4q
+) so design process can continue with some actual content.
+    * https://github.com/conda-incubator/assets/issues/2
+    * Anaconda needs legal to sign-off on logo, etc.
+    
+* Conda Community Triage / Conda Triage team so community members and contributors can start helping?
+    * Conda Constructor
+        * GPC - @goanpeca (1-2 hours per week?)
+    * Conda
+        * KF
+        * GPC - @goanpeca (1-2 hours per week?)
+        * CJM
+    * Conda-build
+        * KF
+        * CJM
+        * FF (ocefpaf)
+        * MDT
+    * Conda-Pack
+        * MCG
+    * Ensureconda
+        * 
+    * setup-miniconda / setup-miniforge (github actions)
+        * GPC - @goanpeca (1-2 hours per week?)
+    * grayskull
+        * MDT
+    * conda-mirror?
+    * conda-suggest?
+    * conda-press?
+    * conda-lock?
+    * libronda
+        * MCS
+    * others from https://github.com/conda-incubator?
+
+    
+    * Discussion: 
+        KF is creating/updating process documentation of conda/conda-build
+        Permissions are needed to let people update -  need github ids
+        members currently on call will be added for issue-management permissions to edit on repositories
+        Triage during community call? (FF, MCG)- needs scheduling - some time in november?
+        Kick-off meeting?
+
+* Organize list on this hackmd on 'short term'/'medium term'/'long term' actionable items?
+    * Priority order:
+        * Roadmap: https://github.com/conda/conda/milestone/38
+        * CLA
+
+### New Agenda Items
+* N/A
+
+### Outstanding Items From the Previous Meeting
+* N/A
+
+
+### Active Votes
+* N/A
+
+### Subteam Updates
+* Specification Subteam
+
+#### Open PRs
+* N/A
+
+## Discussion
+* 
+
+## Action items
+
+* Schedule community issue triage kick-off mtg -- ??
+* Anaconda action item: get clarification about using "conda" trademark in community project names
+
+## Previous Meetings
+
+
+### Last Meeting 202001006
+
+#### Action Items
+
+
+#### Discussion
+* Specification Subteam
+    * New format for recipes
+        * slides: https://docs.google.com/presentation/d/19R-h7yeyMF2BnzLKu8UFVVF1npgSwhcvorqBKnxy6qE/edit?usp=sharing 
+        * Tool present for converting existing recipes
+        * Goal:
+            - Machine parsability (move information out of Jinja control structures, magic comments)
+            - Cleaner model for multiple output recipes
+            - https://github.com/mamba-org/conda-specs
+
+* Extension on Depfinder project
+    * CW: 
+        * https://github.com/regro/libcfgraph/tree/master/import_maps
+        * https://conda-forge.org/blog/posts/2020-10-02-versions/
+
+
+### Move to Issue Tracker
+
+
+### Current Action Items

--- a/meetings/archive/20201102_agenda_and_minutes.md
+++ b/meetings/archive/20201102_agenda_and_minutes.md
@@ -1,0 +1,152 @@
+# 2020-11-02 Conda Community Meeting
+
+****
+
+[Meeting link](https://meet.google.com/owq-kbca-abk)
+
+[What time is the meeting in my time zone](https://arewemeetingyet.com/Chicago/2020-11-02/09:00/b/Conda%20community%20meeting)
+
+[Last Meeting's Agenda and Minutes](https://github.com/conda-incubator/governance/tree/master/meetings)
+
+## Attendees
+
+* **Name (Initials) (githubid)**
+* Megan Yancy MCY @myancy-anaconda
+* Amy Williams AW
+* Cheng Lee CHL
+* Filipe Fernandes FF @ocefpaf
+* Ray Donnelly RD @mingwandroid
+* Kale Franz KF @kalefranz
+* Bill Batey BB @lumbrefrio
+* Peter Wang PW @pzwang
+* Crystal Soja CAS
+* 
+* Matt B. @beckermr
+
+
+## Agenda
+
+* Welcome
+
+### Announcements
+
+
+### Standing Items
+
+* Schedule community issue triage kick-off mtg -- ??
+  Draft of triaging guidelines: https://gist.github.com/kalefranz/0c812846e5d755c29b067ba56b8a8ddf
+  * KF will schedule
+  
+* Anaconda: get clarification about using "conda" trademark in community project names
+    * With Anaconda legal/marketing; hoping to get a blanket statement à la Arduino/Debian
+* Website: Check the draft for [text on the website](https://docs.google.com/document/d/1gECzDW4QluEM2-00xrxoseKLD2MaD9k_xvcwj3cxtMg/edit#heading=h.j4l7zepliw4q) so design process can continue with some actual content.
+    * https://github.com/conda-incubator/assets/issues/2
+    * Anaconda needs legal to sign-off on logo, etc.
+    
+* Conda Community Triage / Conda Triage
+    * Conda Constructor
+    * Conda
+        * @kalefranz: 
+            * Conda GitHub org cleanup: 
+                * Review a list of proposed repositories to remove from github.com/conda and move elsewhere.
+                  https://docs.google.com/spreadsheets/d/1QZGJ59GshRxyqLGhNohGn-zNjX2EU-Or9jh6x86fZes
+    * Conda-build
+    * Conda-Pack
+    * Ensureconda
+    * setup-miniconda / setup-miniforge (github actions)
+    * grayskull
+    * conda-mirror
+    * conda-suggest
+    * conda-press
+    * conda-lock
+    * libronda
+
+* Organize list on this hackmd on 'short term'/'medium term'/'long term' actionable items?
+    * Priority order:
+        * Roadmap: https://github.com/conda/conda/milestone/38
+        * CLA
+            * Look into modified CLA - organizations and other companies?
+
+### New Agenda Items
+* N/A
+
+### Outstanding Items From the Previous Meeting
+* N/A
+
+
+### Active Votes
+* N/A
+
+### Subteam Updates
+
+#### Open PRs
+* N/A
+
+## Discussion
+* 
+
+## Action items
+
+* Anaconda: Organizational-level CLA
+
+## Previous Meetings
+
+
+### Last Meeting 202001020
+* Website: Check the draft for [text on the website](https://docs.google.com/document/d/1gECzDW4QluEM2-00xrxoseKLD2MaD9k_xvcwj3cxtMg/edit#heading=h.j4l7zepliw4q
+) so design process can continue with some actual content.
+    * https://github.com/conda-incubator/assets/issues/2
+    * Anaconda needs legal to sign-off on logo, etc.
+    
+* Conda Community Triage / Conda Triage team so community members and contributors can start helping?
+    * Conda Constructor
+        * GPC - @goanpeca (1-2 hours per week?)
+    * Conda
+        * KF
+        * GPC - @goanpeca (1-2 hours per week?)
+        * CJM
+    * Conda-build
+        * KF
+        * CJM
+        * FF (ocefpaf)
+        * MDT
+    * Conda-Pack
+        * MCG
+    * Ensureconda
+        * 
+    * setup-miniconda / setup-miniforge (github actions)
+        * GPC - @goanpeca (1-2 hours per week?)
+    * grayskull
+        * MDT
+    * conda-mirror?
+    * conda-suggest?
+    * conda-press?
+    * conda-lock?
+    * libronda
+        * MCS
+    * others from https://github.com/conda-incubator?
+
+    
+    * Discussion: 
+        KF is creating/updating process documentation of conda/conda-build
+        Permissions are needed to let people update -  need github ids
+        members currently on call will be added for issue-management permissions to edit on repositories
+        Triage during community call? (FF, MCG)- needs scheduling - some time in november?
+        Kick-off meeting?
+
+* Organize list on this hackmd on 'short term'/'medium term'/'long term' actionable items?
+    * Priority order:
+        * Roadmap: https://github.com/conda/conda/milestone/38
+        * CLA
+
+#### Action Items
+* Schedule community issue triage kick-off mtg -- ??
+* Anaconda action item: get clarification about using "conda" trademark in community project names
+
+#### Discussion
+
+
+### Move to Issue Tracker
+
+
+### Current Action Items

--- a/meetings/archive/20201117_agenda_and_minutes.md
+++ b/meetings/archive/20201117_agenda_and_minutes.md
@@ -1,0 +1,142 @@
+# 2020-11-17 Conda Community Meeting
+
+****
+
+[Meeting link](https://meet.google.com/owq-kbca-abk)
+
+[What time is the meeting in my time zone](https://arewemeetingyet.com/Chicago/2020-11-17/09:00/b/Conda%20community%20meeting)
+
+[Last Meeting's Agenda and Minutes](https://github.com/conda-incubator/governance/tree/master/meetings)
+
+## Attendees
+
+| Name | Initials | Affiliation | Username |
+| ---- | -------- |------------ | -------- |
+| Megan Yancy | MCY | Anaconda | @myancy-anaconda |
+| Sebastien Awwad | SA | Anaconda distro team | @awwad |
+| Kale Franz | KF | Anaconda | @kalefranz |
+| Cheng Lee | CHL | Anaconda | @chenghlee |
+| Michael Grant | MG | Anaconda | mcg1969 |
+| CJ Wright | CJ | Lab49| @cj-wright|
+| Matthew Becker | | | beckermr |
+| Amy Williams | AW | Anaconda | awilliams-anaconda |
+| Filipe Fernandes | FF | | @ocefpaf |
+| Gonzalo Peña-Castellanos | GPC | Quansight | @goanpeca |
+| Crystal Soja | CAS | Anaconda | csoja |
+| Marcelo Duarte Trevisani | MDT | conda-forge | @marcelotrevisani |
+| Marcel Bargull | MB | conda-forge/Bioconda | @mbargull |
+| Michael Sarahan | MCS |  | @msarahan |
+
+## Agenda
+
+* Welcome
+
+### Announcements
+
+
+### Standing Items
+* N/A
+
+### New Agenda Items
+* Rotating Meeting Facilitator
+    * Call for volunteers
+    * (@goanpeca)
+* Anaconda: Organizational-level CLA
+    * No current updates
+* Overview of artifact verification / package signing for conda (adaptation of The Update Framework) -- SA
+     * Slides here: https://docs.google.com/presentation/d/1YkY62Q8DVfCpeYq7_iI7d5aWeYQnj7ghtPWUDRHSSNE/edit?usp=sharing
+* conda-pack issue curation: labeling completed, contributors invited - MG
+    * Call for volunteers
+    * https://github.com/conda/conda-pack/issues
+
+### Outstanding Items From the Previous Meeting
+* N/A
+
+
+### Active Votes
+* Triaging and Issue Tracking meeting (KF): https://doodle.com/poll/cqpw3pkpew4tex5r
+    * Please vote!
+
+### Subteam Updates
+
+#### Open PRs
+* N/A
+
+## Discussion
+* Ways to address diversity inclusiveness issues
+    * new sub-team - charter for maintaining and advancing conda-forge as a diverse community, try to grow. Charter is dynamic. Looking for those who are not core contributors of conda-forge.
+    * Would like input on document
+    * https://github.com/conda-forge/conda-forge.github.io/pull/1187
+* Availability of artifact verification features to other pieces of software (than conda):
+    * SA: @Wolf,  Please be aware that at first, we're offering the trust and signing data to paid folks, because... lights on.  But I don't see why support for consuming that data shouldn't be handled in any package manager frontend talking to the repository.  There's a project with the majority of the low-level code and a set of algorithms.  The process of integrating that into conda (or other managers) is a delicate thing, so I'm hoping that the guidelines are helpful enough... but this will improve after conda integration.
+    * Wolf: sure. with quetz we're working hard to support mirroring of conda-channels (specifically conda-forge), and this trust & verification is pretty integral for that so ... we might have to implement this anyways, and then it would probably make sense to do it in the same fashion as upstream
+    * SA: that'd be good, yeah. We can talk about the TUF work underlying it at the least
+
+## Action items
+
+
+
+## Previous Meetings
+
+
+### Last Meeting 202001102
+
+* Schedule community issue triage kick-off mtg -- ??
+  Draft of triaging guidelines: https://gist.github.com/kalefranz/0c812846e5d755c29b067ba56b8a8ddf
+  * KF will schedule
+  * Update: Please give interest and availability for first meeting at https://doodle.com/poll/cqpw3pkpew4tex5r
+  
+* Anaconda: get clarification about using "conda" trademark in community project names
+    * With Anaconda legal/marketing; hoping to get a blanket statement à la Arduino/Debian
+* Website: Check the draft for [text on the website](https://docs.google.com/document/d/1gECzDW4QluEM2-00xrxoseKLD2MaD9k_xvcwj3cxtMg/edit#heading=h.j4l7zepliw4q) so design process can continue with some actual content.
+    * https://github.com/conda-incubator/assets/issues/2
+    * Anaconda needs legal to sign-off on logo, etc.
+    
+* Conda Community Triage / Conda Triage
+    * Conda Constructor
+    * Conda
+        * @kalefranz: 
+            * Conda GitHub org cleanup: 
+                * Review a list of proposed repositories to remove from github.com/conda and move elsewhere.
+                  https://docs.google.com/spreadsheets/d/1QZGJ59GshRxyqLGhNohGn-zNjX2EU-Or9jh6x86fZes
+                * Update: Waiting on Anaconda IT department to create repositories under github.com/ContinuumIO
+    * Conda-build
+    * Conda-Pack
+    * Ensureconda
+    * setup-miniconda / setup-miniforge (github actions)
+    * grayskull
+    * conda-mirror
+    * conda-suggest
+    * conda-press
+    * conda-lock
+    * libronda
+
+* Organize list on this hackmd on 'short term'/'medium term'/'long term' actionable items?
+    * Priority order:
+        * Roadmap: https://github.com/conda/conda/milestone/38
+        * CLA
+            * Look into modified CLA - organizations and other companies?
+
+    
+    * Discussion: 
+        KF is creating/updating process documentation of conda/conda-build
+        Permissions are needed to let people update -  need github ids
+        members currently on call will be added for issue-management permissions to edit on repositories
+        Triage during community call? (FF, MCG)- needs scheduling - some time in november?
+        Kick-off meeting?
+
+* Organize list on this hackmd on 'short term'/'medium term'/'long term' actionable items?
+    * Priority order:
+        * Roadmap: https://github.com/conda/conda/milestone/38
+        * CLA
+
+#### Action Items
+* Anaconda: Organizational-level CLA
+
+#### Discussion
+
+
+### Move to Issue Tracker
+
+
+### Current Action Items

--- a/meetings/archive/20201201_agenda_and_minutes.md
+++ b/meetings/archive/20201201_agenda_and_minutes.md
@@ -1,0 +1,126 @@
+# 2020-12-01 Conda Community Meeting
+
+* [Meeting link](https://meet.google.com/owq-kbca-abk)
+* [What time is the meeting in my time zone](https://arewemeetingyet.com/Chicago/2020-12-01/09:00/b/Conda%20community%20meeting)
+* [Last Meeting's Agenda and Minutes](https://github.com/conda-incubator/governance/tree/master/meetings)
+
+## Attendees
+
+| Name | Initials | Affiliation | Username |
+| ---- | -------- |------------ | -------- |
+| Gonzalo Peña-Castellanos | GPC | Quansight | @goanpeca |
+| Megan Yancy | MCY | Anaconda | @myancy-anaconda |
+| Marius van Niekerk | MvN | Flatiron Health | @mariusvniekerk |
+| Cheng Lee | CHL | Anaconda | @chenghlee |
+| Eric Dill | ED | DTN | @ericdill |
+| Crystal Soja | CAS | Anaconda | @csoja |
+| Christopher J "CJ" Wright | CJ | Lab49 | @cj-wright |
+| Keith Kraus | KK | NVIDIA | @kkraus14 |
+| Filipe Fernandes | FF | IOOS | ocefpaf |
+| Michael Grant | MG | Anaconda | mcg1969 |
+| Connor Martin | CJM | Anaconda |@cjmartian |
+| Marcel Bargull | MB | Bioconda / conda-forge | @mbargull |
+| Wolf Vollprecht | WV | QuantStack / mamba | @wolfv |
+| Matthew Becker | MRB | -- | @beckermr |
+| Marcelo Duarte Trevisani | MDT | conda-forge | @marcelotrevisani |
+| Michael Sarahan | MCS | RStudio | @msarahan |
+
+## Agenda
+
+* Welcome
+
+### Announcements
+
+
+### Standing Items
+* Anaconda: Organizational-level CLA
+    * No current updates.
+
+
+### New Agenda Items
+
+* Rotating Meeting Facilitator
+    * Call for volunteers
+    * Who wants to go next?
+
+* Conda Triaging and Issue Tracking meeting took place.
+    * Meeting: Kale, Marcel, Gonzalo, Cheng
+    * Splitting responsibility by day: each person triages issues that come in that day
+    * [conda-triage](https://conda.slack.com/archives/C01FMCT5W84)
+
+* Given that pip install conda still "works" but obviously installs something wildly out of date and non functional should we yank the releases on pypi ? (@marius)
+    * Existing blog posts refer to conda being pip installable
+    * Possible solutions:
+        * could `pipx install conda` with a standalone binary?
+        * `pip install conda` forcibly fails with a link to miniconda installer?
+        * Remove the packages but reserve the package name?
+        * _Very_ long term: cool but probably impractical due to major technical challenges
+    * Short term fix: Anaconda will replace with newer stub package on PyPI.
+        * Create a `conda-stub` repository that creates folder with an empty package.
+        * Will not remove package (without annoucement) to avoid breaking existing users & workflows.
+        * Issue: https://github.com/conda/conda/issues/10388
+
+* Where are the conda-standalone binaries these days?
+    * Since all i know of is https://repo.anaconda.com/pkgs/misc/conda-execs
+    * Short term I am unpacking the ones from https://anaconda.org/anaconda/conda-standalone (for use in ensureconda)
+        * `conda install conda-standalone` -> installs into `$CONDA_PREFIX/standalone_conda`
+        * https://repo.anaconda.com/pkgs/main/${subdir}/conda-standalone*.tar.bz2
+    * Ray has pushed for updating these binaries for each conda release.
+    * Anaconda needs to address internal CI issues around automating executable signing. (Currently use a manual process of downloading, re-signing, and re-uploading executables.)
+
+* [x] (MRB) package copying and package metadata on anaconda.org
+    * We are having an issue in conda-forge where when we [copy](https://api.anaconda.org/docs#!/package/post_copy_package_owner_login_package_name_version_basename) packages from one user to another using the copy API endpoint, the metadata per package (doc_url, dev_url etc) displayed on anaconda.org is erased. We need this metadata for certain packages, especially cudatoolkit.
+    * We need two fixes:
+        * support for patch requests for the anaconda.org `/package/{owner_login}/{package_name}` API endpoint so that we can restore the metadata
+        * fix the copy endpoint so it does not delete this metadata
+    * These will let us fix the packages we have and make sure it doesn't happen for new packages.
+    * issue: https://github.com/Anaconda-Platform/anaconda-client/issues/556
+
+* Audit (CJ)
+	* Using depfinder to check:
+		* Accurate 
+		* Under specified
+		* Over specified
+		* Under and over specified
+		* Errored
+    * Link to the information
+    	* https://github.com/conda-forge/by-the-numbers
+        * https://github.com/conda-forge/by-the-numbers/blob/master/audit_accuracy.ipynb
+
+* Raises the question of how to handle optional dependencies and/or sub-packages?
+    * Like RPM provides?
+
+* Additional test "keys" for conda-build (WV)
+    * I wrote down some ideas here: https://github.com/mamba-org/boa/issues/93
+    * Is conda-build interested in these tests? (CHL: yes; please open issue on conda-build GH)
+    * Fits into concepts for conda-verify
+
+### Outstanding Items From the Previous Meeting
+
+* N/A
+
+### Active Votes
+
+
+### Subteam Updates
+
+
+#### Open PRs
+
+* N/A
+
+## Discussion
+
+
+## Action items
+
+## Last meeting points (2020-11-17)
+
+* Ways to address diversity inclusiveness issues
+    * new sub-team - charter for maintaining and advancing conda-forge as a diverse community, try to grow. Charter is dynamic. Looking for those who are not core contributors of conda-forge.
+    * Would like input on document
+    * https://github.com/conda-forge/conda-forge.github.io/pull/1187
+* Availability of artifact verification features to other pieces of software (than conda):
+    * SA: @Wolf,  Please be aware that at first, we're offering the trust and signing data to paid folks, because... lights on.  But I don't see why support for consuming that data shouldn't be handled in any package manager frontend talking to the repository.  There's a project with the majority of the low-level code and a set of algorithms.  The process of integrating that into conda (or other managers) is a delicate thing, so I'm hoping that the guidelines are helpful enough... but this will improve after conda integration.
+    * Wolf: sure. with quetz we're working hard to support mirroring of conda-channels (specifically conda-forge), and this trust & verification is pretty integral for that so ... we might have to implement this anyways, and then it would probably make sense to do it in the same fashion as upstream
+    * SA: that'd be good, yeah. We can talk about the TUF work underlying it at the least

--- a/meetings/archive/20201215_agenda_and_minutes.md
+++ b/meetings/archive/20201215_agenda_and_minutes.md
@@ -1,0 +1,82 @@
+# 2020-12-15 Conda Community Meeting
+
+* [Meeting link](https://meet.google.com/owq-kbca-abk)
+* [What time is the meeting in my time zone](https://arewemeetingyet.com/Chicago/2020-12-01/09:00/b/Conda%20community%20meeting)
+* [Last Meeting's Agenda and Minutes](https://github.com/conda-incubator/governance/tree/master/meetings)
+
+## Attendees
+
+| Name | Initials | Affiliation | Username |
+| ---- | -------- |------------ | -------- |
+|      |          |             |          |
+| Michael Grant | mcg | Anaconda | mcg1969 |
+| Crystal Soja  |  CAS   |  Anaconda   |  @csoja   |
+| Filipe Fernandes | FF          | conda-forge | | @ocefpaf          |
+| Matthew Becker     | MRB         | conda-forge            | @beckermr |
+| Marcel Bargull | MB | Bioconda/conda-forge | @mbargull |
+| Christopher "CJ" Wright | CJ | Lab49 | @cj-wright |
+| Connor Martin | CJM | Anaconda | @cjmartian |
+| Cheng H. Lee | CHL | Anaconda | @chenghlee |
+| Michael Sarahan | MCS | RStudio | @msarahan |
+
+
+## Agenda
+
+* Welcome
+* Is there a meeting happening on the 29th?
+    * Voice vote to cancel the 29th.
+* Host for next meeting? 
+
+### Announcements
+* (FF) 5K on conda messaging granted from NumFocus
+    * Cheng, Marcelo to work on it.
+
+### Standing Items
+* Anaconda: Organizational-level CLA
+    * No current updates.
+    * Existing CLA: consider updating to clarify a real name is required
+
+
+### New Agenda Items
+
+* Dropping Python 2 support in conda, conda-build in base environment
+    * https://github.com/conda/conda/issues/10180
+    * https://github.com/conda/conda-build/issues/4024
+    * Decision on Python 3.6 vs 3.7? (3.7: UTF-8 by default; data classes)
+    * (MG, CS): In favor of conda on 3.6, conda-build on 3.7
+    * (MB) concern raised about lag in conda development if significant 3.x refactoring is done
+    * (MB) concern about noarch <-> arch upgrade process, raise issue if a shadowed update is available
+    * (MB) miniconda 4.5.4 last Py3.6 installer
+    * (MS) separate CLI to make such decisions easier; longer term project.
+    * (CHL) staying with 3.6 in 2021 unless something else comes up.
+* Should we have a permanent resource (e.g., blog post) saying why users should upgrade? (Probably yes)
+* Who else should we invite to this meeting?
+    * Intel
+    * IBM (POWER, RedHat -> containers)
+    * Pangeo
+    * CZI
+    * HPC centers
+    * Tensorflow, Pytorch, etc.
+    * Others, as needed for specific topics
+
+
+### Outstanding Items From the Previous Meeting
+
+* N/A
+
+### Active Votes
+
+
+### Subteam Updates
+
+
+#### Open PRs
+
+* N/A
+
+## Discussion
+
+
+## Action items
+
+## Last meeting points (2020-12-01)

--- a/meetings/archive/20210112_agenda_and_minutes.md
+++ b/meetings/archive/20210112_agenda_and_minutes.md
@@ -1,0 +1,81 @@
+# 2021-01-12 Conda Community Meeting
+
+* [Meeting link](https://meet.google.com/owq-kbca-abk)
+* [What time is the meeting in my time zone](https://arewemeetingyet.com/Chicago/2020-12-01/09:00/b/Conda%20community%20meeting)
+* [Last Meeting's Agenda and Minutes](https://github.com/conda-incubator/governance/tree/master/meetings)
+
+## Attendees
+
+| Name | Initials | Affiliation | Username |
+| ---- | -------- |------------ | -------- |
+| Marius van Niekerk    | MvN         | Flatiron Health        | mariusvniekerk              |
+|Isabela Presedo-Floyd      | IRPF         | Quansight Labs            | isabela-pf         |
+| Megan Yancy     | MCY         | Anaconda            | myancy-anaconda         |
+| Eric Dill | ED | DTN | ericdill |
+| Connor Martin | CJM | anaconda | cjmartian |
+| Matthew Becker     | MRB         |  conda-forge           |  beckermr        |
+| Uwe Korn | UK | conda-forge   | xhochy |
+| Crystal Soja | CS | anaconda | csoja |
+| Michael Grant | MG | anaconda | mcg1969 |
+| Keith Kraus | KK | NVIDIA | kkraus14 |
+| Michael Sarahan | MCS | RStudio | msarahan |
+
+
+## Agenda
+
+* Welcome
+* Host for next meeting? - MCY
+
+### Announcements
+*
+
+### Standing Items
+* Anaconda: Organizational-level CLA
+
+### New Agenda Items
+* Conda community website mockups are up for feedback.
+    * https://github.com/conda-incubator/assets/issues/2
+    * Please provide feedback!
+    * Question on Trademarks
+    * Vote to come later
+
+### Outstanding Items From the Previous Meeting
+
+* Blog post regarding why users should update to Python 3
+* Outreach to invite more organizations to join this meeting
+
+### Active Votes
+
+
+### Subteam Updates
+
+
+#### Open PRs
+
+* N/A
+
+## Discussion
+
+## Action items
+* Anaconda: update on organizational-level CLA
+## Last meeting points (2020-12-15)
+
+* Dropping Python 2 support in conda, conda-build in base environment
+    * https://github.com/conda/conda/issues/10180
+    * https://github.com/conda/conda-build/issues/4024
+    * Decision on Python 3.6 vs 3.7? (3.7: UTF-8 by default; data classes)
+    * (MG, CS): In favor of conda on 3.6, conda-build on 3.7
+    * (MB) concern raised about lag in conda development if significant 3.x refactoring is done
+    * (MB) concern about noarch <-> arch upgrade process, raise issue if a shadowed update is available
+    * (MB) miniconda 4.5.4 last Py3.6 installer
+    * (MS) separate CLI to make such decisions easier; longer term project.
+    * (CHL) staying with 3.6 in 2021 unless something else comes up.
+* Should we have a permanent resource (e.g., blog post) saying why users should upgrade? (Probably yes)
+* Who else should we invite to this meeting?
+    * Intel
+    * IBM (POWER, RedHat -> containers)
+    * Pangeo
+    * CZI
+    * [x] MRB: HPC centers
+    * Tensorflow, Pytorch, etc.
+    * Others, as needed for specific topics

--- a/meetings/archive/20210126_agenda_and_minutes.md
+++ b/meetings/archive/20210126_agenda_and_minutes.md
@@ -1,0 +1,79 @@
+# DRAFT - 2021-01-26 Conda Community Meeting
+
+* [Meeting link](https://meet.google.com/owq-kbca-abk)
+* [What time is the meeting in my time zone](https://arewemeetingyet.com/Chicago/2021-01-26/09:00/b/Conda%20Community%20Meeting)
+* [Last Meeting's Agenda and Minutes](https://github.com/conda-incubator/governance/tree/master/meetings)
+
+## Attendees
+
+| Name | Initials | Affiliation | Username |
+| ---- | -------- |------------ | -------- |
+|  CJ Wright    |   CJ       |   Lab49          |   @cj-wright       |
+| Cheng H. Lee  |  CHL     | Anaconda        | @chenghlee        |
+| Ralf Gommers  |   RG       | Quansight        | @rgommers          |
+| Amy Williams  | AW         | Anaconda         | @adwilliams81      |
+| Eric Dill     | ED         | DTN              | @ericdill          |
+| Michael Grant | MG         | Anaconda         | @mcg1969           |
+|               |            |                  |                    |
+
+
+## Agenda
+
+* Welcome
+
+
+### Announcements
+_None_
+
+
+### Standing Items
+* Anaconda: Organizational-level CLA
+    * Anaconda legal team contacted; moving forward with Feb. delivery
+* Conda Community website mockups
+    * https://github.com/conda-incubator/assets/issues/2
+* Blog post regarding why users should update to Python 3
+* Outreach to invite more organizations to join this meeting
+
+
+### New Agenda Items
+* Revisit the meeting schedule. Should we change it to accomodate more people?
+    * Maybe a new doodle? -> (CHL) Will put schedule a poll and announce via Slack, email
+    * Ideally we should also ask conda-forge to be bi-weekly so we can use the same date and time allowing people attending both to reverse the slot for conda-community and conda-forge.
+    * (CHL) Reach out to Intel, IBM to join community calls; (PW) Apple, Netflix; (RG) Pytorch
+
+* Python Symbol table of conda-forge packages
+    * https://github.com/symbol-management/cf-symbol-table
+
+
+### Outstanding Items From the Previous Meeting
+
+
+### Active Votes
+
+
+### Subteam Updates
+
+
+#### Open PRs
+
+* N/A
+
+## Discussion
+
+## Action items
+* Anaconda: update on organizational-level CLA
+ 
+## Last meeting points (2020-1-11)
+* Conda Community website mockups
+* Dropping Python 2 support in conda, conda-build in base environment
+    * https://github.com/conda/conda/issues/10180
+    * https://github.com/conda/conda-build/issues/4024
+* Should we have a permanent resource (e.g., blog post) saying why users should upgrade?
+* Who else should we invite to this meeting?
+    * Intel
+    * IBM (POWER, RedHat -> containers)
+    * Pangeo
+    * CZI
+    * [x] MRB: HPC centers
+    * Tensorflow, PyTorch, etc.
+    * Others, as needed for specific topics

--- a/meetings/archive/20210303_agenda_and_minutes.md
+++ b/meetings/archive/20210303_agenda_and_minutes.md
@@ -1,0 +1,89 @@
+# 2021-03-03 Conda Community Meeting
+
+* [Meeting link](https://meet.google.com/owq-kbca-abk)
+* [What time is the meeting in my time zone](https://arewemeetingyet.com/Chicago/2021-03-03/11:00/b/Conda%20community%20meeting)
+* [Last Meeting's Agenda and Minutes](https://github.com/conda-incubator/governance/tree/master/meetings)
+
+
+## Attendees
+
+| Name         | Initials | Affiliation | Username   |
+| ------------ | -------- |------------ | ---------- |
+| Cheng H. Lee | CHL      | Anaconda    | @chenghlee |
+| Filipe       | FF       | conda-forge | @ocefpaf   |
+|   |   |   |   |
+
+
+## Agenda
+
+* Welcome
+
+
+### Announcements
+
+* Anaconda: Organizational-level CLA
+    * Anaconda legal has clarified CLA language to cover both individuals and organizations.
+    * Currently working with Anaconda IT to update links and PDF e-form.
+
+
+### Standing Items
+
+* Conda Community website mockups
+    * https://github.com/conda-incubator/assets/issues/2
+* Outreach to invite more organizations to join this meeting
+
+
+### New Agenda Items
+
+* conda: working on new conda messaging feature
+    * https://github.com/conda/conda/issues/10118
+    * Allow packagers to include a file that will display a message before installating package into an environment.  (Similar to what some maintainers do with pre-link scripts but without executable code)
+    * Use cases: EULA, deprecation additional installation instructions, etc.
+    * Funded by NumFOCUS small grant
+    * Will sync with mamba team to make sure they support that feature
+* conda-forge:
+    * Outreachy to update documentation on bot
+    * Google season of docs (staged-recipes, recipes); would like someone from Anaconda to review
+* micromamba:
+    * virtual packages (`nvidia-smi` rather loading the DSO)
+    * config file loading
+* Bundling/vendoring of dependencies
+    * Something to think about as we expand ecosystem (CRAN, NPM, etc.)
+    * Learning from experiences of Linux distros unbundling packages in pip
+    * https://github.com/pypa/pip/issues/9677
+    * conda-forge: unpinned certifi, win-certstore
+    * https://github.com/mamba-org/mamba/issues/589
+* Name squatting attacks against PyPI
+    * Impacted CuPy
+    * Will need to hold on to `conda`, `conda-build` names, even if we remove the associated packages
+    * How do we protect conda ecosystem? (more unique identifiers; namespace separation)
+* Source trustworthiness
+    * Watching for curl, wget, other network access
+    * Does conda-build have the ability to just fetch sources?
+        * (CHL) if not, would be a nice feature to have
+    * (Allow us to perform actual build on isolated systems)
+
+
+### Outstanding Items From the Previous Meeting
+
+
+### Active Votes
+
+
+### Subteam Updates
+
+
+### Open PRs
+
+
+## Discussion
+
+
+## Action items
+
+* (CHL) Getting conda community 
+
+
+## Last meeting points (2020-01-26)
+
+* Updated meeting date & time

--- a/meetings/archive/20210317_agenda_and_minutes.md
+++ b/meetings/archive/20210317_agenda_and_minutes.md
@@ -1,0 +1,81 @@
+# 2021-03-17 Conda Community Meeting
+
+* [Meeting link](https://meet.google.com/owq-kbca-abk)
+* [What time is the meeting in my time zone](https://arewemeetingyet.com/Chicago/2021-03-17/11:00/b/Conda%20community%20meeting)
+* [Last Meeting's Agenda and Minutes](https://github.com/conda-incubator/governance/tree/master/meetings)
+
+
+## Attendees
+
+| Name         | Initials | Affiliation | Username   |
+| ------------ | -------- |------------ | ---------- |
+| Cheng H. Lee | CHL      | Anaconda    | @chenghlee |
+| CJ Wright | CJ      | Lab49    | @CJ-Wright |
+
+
+## Agenda
+
+* Welcome
+
+
+### Announcements
+
+* Apologies for the daylight savings scheduling oops. Will move 1 hour ahead for next meeting.
+* Berryconda (support for 32-bit ARMv7l) looking for a new maintainer: https://github.com/jjhelmus/berryconda/issues/83
+
+
+
+### Standing Items
+
+* Conda Community website mockups
+* Outreach to invite more organizations to join this meeting
+
+
+### New Agenda Items
+
+* Upcoming conda 4.10.0 release (planned around end of March, early April)
+    * Formally dropping support for Python 2.7, Python < 3.6 (_in the base environment_)
+        * https://github.com/conda/conda/issues/10180
+        * conda-forge, defaults have not supported Py2.7 since 4.8.3 (Mar 2020), Py3.5 since 4.5.11 (Aug 2018)
+        * This only impacts the base environment. Support for non-base Py2.7, < 3.6 envs will continue indefinitely.
+    * Introducing support for artifact verification
+        * First release: sign and verifies metadata in repodata.json
+        * Currently only available as _pilot_ program to subset of Anaconda customers
+        * Mid- to long-term goals include:
+            * Making signed metadata on defaults
+            * Allowing channels like conda-forge to sign packages & metadata
+        * Soliciting community input on signature specifications, functional requirements, etc.
+            * Link to Sebastian's talk: ...
+        * Conda-content-trust: 
+    * Other fixes: https://github.com/conda/conda/milestone/47
+* New platforms being added to defaults (repo.anaconda.com)
+    * linux-aarch64: targeting "server-class" ARM cores (e.g., Neoverse), but should (mostly) work with other 64-bit ARM CPUs (e.g., Raspi3/4)
+    * linux-s390x: support for RHEL, Ubuntu, SLES on z14, z15
+    * Anaconda Individual Edition installers available starting 2020.04
+* AST & symbol inspection:
+    * https://cf-ast-symbol-table.web.cern.ch/api/v2/symbols/
+    * https://cf-ast-symbol-table.web.cern.ch/api/v2/symbol_table/
+    * https://github.com/symbol-management/api-match-audit
+    * Chris Burr: used pwntools to pull out C symbols
+    * Working on adding relative imports; will require data model change
+
+
+### Outstanding Items From the Previous Meeting
+
+
+### Active Votes
+
+
+### Subteam Updates
+
+
+### Open PRs
+
+
+## Discussion
+
+
+## Action items
+
+
+## Last meeting points (2020-01-26)

--- a/meetings/archive/20210331_agenda_and_minutes.md
+++ b/meetings/archive/20210331_agenda_and_minutes.md
@@ -1,0 +1,69 @@
+# 2021-03-31 Conda Community Meeting
+
+* [Meeting link](https://meet.google.com/owq-kbca-abk)
+* [What time is the meeting in my time zone](https://arewemeetingyet.com/Chicago/2021-03-31/12:00/b/Conda%20community%20meeting)
+* [Last Meeting's Agenda and Minutes](https://github.com/conda-incubator/governance/tree/master/meetings)
+
+
+## Attendees
+
+| Name            | Initials | Affiliation | Username    |
+| --------------- | -------- |------------ | ----------- |
+| Cheng H. Lee    | CHL      | Anaconda    | @chenghlee  | 
+| Filipe F.       | FF       | conda-forge | @ocefpaf    |
+| John Lee        | JL       | Quansight   |             |
+| Travis Oliphant | TEO.     | OpenTeams   | @teoliphant |
+| Fabio Pliger    | FP       | Anaconda    | @fpliger    |
+| Sebastien Awwad | SA       | Anaconda    | @awwad      |
+| Daniel Bast     | DB       | Anaconda    | @dbast      |
+
+
+## Agenda
+
+* Welcome
+
+
+### Announcements
+
+* (Anaconda) conda 4.10.0 now available on conda-canary channel; expected release to defaults on 2021-04-05.
+    * Changelog: https://github.com/conda/conda/blob/4.10.0/CHANGELOG.md
+* (Anaconda) Expect Individual Edition 2021.04 release in next few weeks
+* Submitted letter of intent to CZI: sponsor mamba development
+
+
+### Standing Items
+
+* Conda Community website mockups
+* Outreach to invite more organizations to join this meeting
+
+
+### New Agenda Items
+
+* Update conda-package-handling:
+    * Fix bug in static libarchive that broke some CI
+* (Anaconda) Planning on updating Linux compilers in defaults
+    * Aiming for GCC 10.x on all architectures
+    * Aiming to remove `conda`, `cos7` from platform triplet --- this has caused issues
+    * Will work with conda-forge to coordinate our compiler stategies
+* Resurrecting community support for 32-bit ARM (berryconda)
+
+
+### Outstanding Items From the Previous Meeting
+
+
+### Active Votes
+
+
+### Subteam Updates
+
+
+### Open PRs
+
+
+## Discussion
+
+
+## Action items
+
+
+## Last meeting points (2020-01-26)

--- a/meetings/archive/20210414_agenda_and_minutes.md
+++ b/meetings/archive/20210414_agenda_and_minutes.md
@@ -1,0 +1,86 @@
+# 2021-04-14 Conda Community Meeting
+
+* [Meeting link](https://meet.google.com/owq-kbca-abk)
+* [What time is the meeting in my time zone](https://arewemeetingyet.com/Chicago/2021-04-14/12:00/b/Conda%20community%20meeting)
+* [Last Meeting's Agenda and Minutes](https://github.com/conda-incubator/governance/tree/master/meetings)
+
+
+## Attendees
+
+| Name               | Initials | Affiliation | Username        |
+| ------------------ | -------- |------------ | --------------- |
+| Cheng H. Lee       | CHL      | Anaconda    | @chenghlee      | 
+| Marcel Bargull     | MB       | Bioconda/cf | @mbargull       |
+| Matthew Becker     | MRB      | cf          | @beckermr       |
+| John Lee           | JL       | Quansight   | @leej3          |
+| Marius van Niekerk | MvN      | cf          | @mariusvniekerk |
+| John Kirkham       | JK       | NVIDIA/cf   | @jakirkham      |
+| Keith Kraus        | KK       | NVIDIA/cf   | @kkraus14       |
+
+## Agenda
+
+* Welcome
+
+
+### Announcements
+
+* (Anaconda) conda-package-handling 1.7.3 now available on defaults
+* (Anaconda) conda 4.10.1 now available on conda-canary channel; expected release to defaults on 2021-04-15.
+    * Changelog: https://github.com/conda/conda/blob/4.10.1/CHANGELOG.md
+
+
+### Standing Items
+
+* Conda Community website mockups
+* Outreach to invite more organizations to join this meeting
+
+
+### New Agenda Items
+
+* (Anaconda) Bumping OS levels required for packages on defaults
+    * Linux: CentOS 7 or newer; more specifically GNU libc >=2.17
+    * OS X/macOS: 10.13 or newer
+    * win-32 deprecated soon...ish.
+    * Needed to support, e.g., MKL >=2020, PyTorch 1.8, etc.
+* Consider reserving `__` prefix for virutal packages.
+    * Nvidia: virtual packages for drivers
+    * Virtual packages as plugins, possibly defined in ``.condarc`?
+        * https://github.com/conda/conda/issues/10131
+* Think through how to support CPU- or other hardware-specific features
+    * Want to avoid subdir explosion
+    * Virtual packages probably a cleaner approach
+    * Library for detecting CPU features
+        * https://github.com/workhorsy/py-cpuinfo
+* "source" subdir, caching sources
+    * Need to preserve the source archives (e.g., bzip2, ICU)
+    * bioconda has cache of tarballs via Galaxy project
+    * updates conda-build to fallback
+* Ways to pass arguments to activation scripts
+    * E.g., munge `*FLAGS` to set `-mcpu=`, `-march=`; `-std=cxxNN`; Windows SDK version
+    * Should be exposed as machine- and human-readable metadata
+* Design doc for 5.0 (action item for CHL)
+    * What we would like to see for next-gen conda metadata
+    * What we would like to see for next-gen conda recipe
+
+
+### Outstanding Items From the Previous Meeting
+
+
+### Active Votes
+
+
+### Subteam Updates
+
+
+### Open PRs
+
+
+## Discussion
+
+
+## Action items
+
+* CHL: start design doc for 5.0
+
+
+## Last meeting points (2020-01-26)

--- a/meetings/archive/20210428_agenda_and_minutes.md
+++ b/meetings/archive/20210428_agenda_and_minutes.md
@@ -1,0 +1,76 @@
+# 2021-04-28 Conda Community Meeting
+
+* [Meeting link](https://meet.google.com/owq-kbca-abk)
+* [What time is the meeting in my time zone](https://arewemeetingyet.com/Chicago/2021-04-28/12:00/b/Conda%20community%20meeting)
+* [Last Meeting's Agenda and Minutes](https://github.com/conda-incubator/governance/tree/master/meetings)
+
+
+## Attendees
+
+| Name               | Initials | Affiliation   | GH Username     |
+| ------------------ | -------- |-------------- | --------------- |
+| Cheng H. Lee       | CHL      | Anaconda      | @chenghlee      |
+| Marcel Bargull     | MB       | Bioconda/cf   | @mbargull       |
+| Wolf Vollprecht    | WV       | QuantStack/cf | @wolfv          |
+| Adrien Delsalle    | AD       | QuantStack    | @adriendelsalle |
+| Matthew Becker     | MRB      | cf            | @beckermr       |
+| Marius van Niekerk | MvN      | cf            | @mariusvniekerk |
+| Sebastien Awwad    | SA       | Anaconda      | @awwad          |
+| John Lee           | JL       | Quansight     | @leej3          |
+
+
+### Introductions
+
+
+### Announcements
+
+* (CJ) Citadel is hiring! (including a position on CJ's team, contact CJ for details)
+* Quantstack is hiring!
+* (CHL) Anaconda is hiring!
+* Quansight is hiring!
+
+
+### Standing Items
+
+* Conda Community website mockups
+* Outreach to invite more organizations to join this meeting
+
+
+### New Agenda Items
+
+* (CJ) NumFocus putting together working group to develop an "OSS for corporations" guide book. -- contact CJ if you want contribute.
+* [conda 5.0 planning](https://hackmd.io/fBdxnoMfTZu9_DKQW9myvA)
+    * Planning release around Q3/Q4 2021
+* [WV / AD] TUF questions for conda-content-trust
+    * Implementation based on TUF but does not directly implement spec (e.g., no `key_id`, distinct metadata protection, multi-channel)
+    * Need to consider multiple repositories (channels) and mutiple authorities
+    * Provide access to data for third-party developers to test against (SA)
+    * Provide spec for repodata information
+* Shipped conda environments without needing conda's shell initialization functions?
+    * Typically works, unless you need something in the activation scripts
+    * Users can set `$PATH` as appropriate or use absolute paths
+* Refactor `conda-index` out of `conda-build`
+* Deprecate `conda-verify` -> merge into `conda-build` post-build checks
+* Scheduling: keep at every 2 weeks at current time, or switch?
+    * Consensus is to keept meetings every two weeks until we hear otherwise. 
+
+
+### Outstanding Items From the Previous Meeting
+
+
+### Active Votes
+
+
+### Subteam Updates
+
+
+### Open PRs
+
+
+## Discussion
+
+
+## Action items
+
+
+## Last meeting points (2020-01-26)

--- a/meetings/archive/20210511_agenda_and_minutes.md
+++ b/meetings/archive/20210511_agenda_and_minutes.md
@@ -1,0 +1,77 @@
+# 2021-05-11 Conda Community Meeting
+
+* [Meeting link](https://meet.google.com/owq-kbca-abk)
+* [What time is the meeting in my time zone](https://arewemeetingyet.com/Chicago/2021-05-11/12:00/b/Conda%20community%20meeting)
+* [Last Meeting's Agenda and Minutes](https://github.com/conda-incubator/governance/tree/master/meetings)
+
+
+## Attendees
+
+| Name               | Initials | Affiliation   | GH Username     |
+| ------------------ | -------- |-------------- | --------------- |
+| Cheng H. Lee       | CHL      | Anaconda      | @chenghlee      |
+| Marcel Bargull     | MB       | Bioconda/cf   | @mbargull       |
+| CJ Wright          | CJ       | Citadel/cf    | @CJ-Wright      |
+| Sebastien Awwad    | SA       | Anaconda      | @awwad          |
+
+
+### Introductions
+* Dan Meador (Anaconda)
+
+
+### Announcements
+
+* Anaconda Individual Edition 2021.04 releasing this week.  In addition to updates, adds linux-aarch64 (Neoverse N1/N2) and linux-s390x as supported platforms.
+* Anaconda (distro & platform) is hiring.
+* Citadel (HPC env and pkg management, contact CJ), is hiring.
+
+
+### Standing Items
+
+* Conda Community website mockups
+* Outreach to invite more organizations to join this meeting
+
+
+### New Agenda Items
+
+* Expect conda 4.10.2 release in the next week or two.
+    * Roadmap: https://github.com/conda/conda/milestone/50
+    * `conda env create` (snakemake, conda lock) vs `conda create`
+        * `env` spec files seem preferred (channels, pip, etc.)
+        * micromamba create reads yaml files
+            * includes (undocumented) extension that allows platform-specific selection
+            * (CHL) willing to pull that into conda itself; document in environment schema.
+* CentOS (8) EOL
+    * Anaconda "defaults": supporting CentOS 7 (glibc 2.17) as default target until it hits EOL in 2024.  If newer glibc needed to build something, will use older, supported versions of Ubuntu or Debian.
+    * conda-forge discussion: https://github.com/conda-forge/conda-forge.github.io/issues/1432
+        * yum requirements, CDTs -> but we can wait till 2024
+    * consider other community-maintained alternatives like Rocky Linux
+    * commercial interest in staying on RHEL (or other rpm-based distros)
+    * adding `__glibc` run constrains
+        * explicit in recipes; run_exports in compiler, sysroot packages; feature in conda build
+        * need to consider what manylinux, other HPC centers, other communities (e.g., nix; R) plan to do
+        * roll our own glibc? Need to consider patches, kernels, etc.
+* Thinking through how to handle compatibility with system packages (glibc, X11, etc.)
+* `yanked` vs `broken`: ways to remove or hide packages from the ecosystem
+* repodata timestamping (or other version management) for reproducibility --- bioconda
+
+
+### Outstanding Items From the Previous Meeting
+
+
+### Active Votes
+
+
+### Subteam Updates
+
+
+### Open PRs
+
+
+## Discussion
+
+
+## Action items
+
+
+## Last meeting points (2020-05-11)

--- a/meetings/archive/20210525_agenda_and_minutes.md
+++ b/meetings/archive/20210525_agenda_and_minutes.md
@@ -1,0 +1,79 @@
+# 2021-05-25 Conda Community Meeting
+
+* [Meeting link](https://meet.google.com/owq-kbca-abk)
+* [What time is the meeting in my time zone](https://arewemeetingyet.com/Chicago/2021-05-25/12:00/b/Conda%20community%20meeting)
+* [Last Meeting's Agenda and Minutes](https://github.com/conda-incubator/governance/tree/master/meetings)
+
+
+## Attendees
+
+| Name               | Initials | Affiliation   | GH Username     |
+| ------------------ | -------- |-------------- | --------------- |
+| Cheng H. Lee       | CHL      | Anaconda      | @chenghlee      |
+| matthew becker     | MRB      | conda-forge   | @beckermr       |
+| Sebastien Awwad    | SA       | Anaconda      | @awwad          |
+| Marcel Bargull     | MB       | Bioconda/cf   | @mbargull       |
+
+
+### Introductions
+
+
+### Announcements
+
+* [AnacondaCON 2021](https://anacondacon.io/): 9 Jun, all virtual. 
+* conda 4.10.2 delayed by ~1 week
+
+
+### Standing Items
+
+* Conda Community website mockups
+* Outreach to invite more organizations to join this meeting
+
+
+### New Agenda Items
+
+* Planning conda-build release
+    * All patches applied as binary; causes issues on Windows & how patch detection works (or doesn't)
+        * https://github.com/conda/conda-build/issues/1973
+        * https://github.com/conda/conda-build/pull/2035
+    * Conda UTF-16 handling:
+        * https://github.com/conda/conda/pull/9946
+        * https://github.com/conda-forge/conda-feedstock/blob/master/recipe/gh9946_utf_16_replacement.patch
+    * `sys.exit(...)` when invoking conda-build via API, rather than CLI. (Should raise Exceptions instead; developer quality-of-life improvement)
+
+* Update to spec (conda, conda-build)
+    * Support for optional deps
+
+* Quetz: plans for authentication support
+    * 5.0+ planning: authn schemes for package servers
+    * Anaconda.org currently uses token-in-URL scheme
+    * mamba: HTTP basic auth, anaconda.org token scheme
+    * User requests for other schemes:
+        * `~/.netrc`
+        * RSA SecurID: https://github.com/conda/conda/pull/10667
+    * (FP) Share APIs, not necessarily code, between mamba & conda for authn
+
+* (CJ) Version 4 symbol database released!
+
+* Packaging con --- more info next week
+
+
+### Outstanding Items From the Previous Meeting
+
+
+### Active Votes
+
+
+### Subteam Updates
+
+
+### Open PRs
+
+
+## Discussion
+
+
+## Action items
+
+
+## Last meeting points (2020-05-11)

--- a/meetings/archive/20210623_agenda_and_minutes.md
+++ b/meetings/archive/20210623_agenda_and_minutes.md
@@ -1,0 +1,75 @@
+# 2021-06-23 Conda Community Meeting
+
+* [Meeting link](https://meet.google.com/owq-kbca-abk)
+* [What time is the meeting in my time zone](https://arewemeetingyet.com/Chicago/2021-06-09/12:00/b/Conda%20community%20meeting)
+* [Last Meeting's Agenda and Minutes](https://github.com/conda-incubator/governance/tree/master/meetings)
+
+
+## Attendees
+
+| Name               | Initials | Affiliation   | GH Username     |
+| ------------------ | -------- |-------------- | --------------- |
+| Cheng H. Lee       | CHL      | Anaconda      | @chenghlee      |
+| Jaime Rodríguez-G. | JRG      | Quansight     | @jaimergp       |
+| John Lee           | JL       | Quansight     | @leej3          |
+| Filipe Fernandes   | FF       | conda-forge   | @ocefpaf        |
+| Sebastien Awwad    | SA       | Anaconda      | @awwad          |
+|     |        |       |           |
+
+
+
+### Introductions
+
+* Jaime Rodríguez-G. (Quantsight)
+
+
+### Announcements
+
+* conda 4.10.2 roadmap items complete; should be tagged today and package released towards end-of-the-week
+* Putting together [Packaging Con](https://packaging-con.org) (2-day virtual conference; beginning of November)
+
+
+### Standing Items
+
+* Conda Community website mockups
+    * Confirmed Anaconda owns the conda.org domain
+    * https://github.com/conda-incubator/assets/issues/2#issuecomment-752871352 - at least get a GH page setup
+* Outreach to invite more organizations to join this meeting
+    * Anaconda has invited Intel, IBM
+
+
+### New Agenda Items
+
+* Robotics + conda packages
+    * [RoboStack](https://github.com/RoboStack)
+    * OSRF + Microsoft: ROS as conda packages for Windows
+* Plugins + conda packages
+    * FreeCAD, QGIS: exploring plug-in manager based on libmamba
+    * https://forum.freecadweb.org/viewtopic.php?style=3&f=42&t=58156&sid=d021658f134cfaf101896af54fb2c275
+    * https://github.com/qgis/QGIS-Enhancement-Proposals/issues/179
+    * Other tools may benefit; e.g.,
+        * ChimeraX; currently handle deps with custom wheels: https://cxtoolshed.rbvi.ucsf.edu/
+        * https://www.ccp4.ac.uk/
+        * https://www.phenix-online.org/
+* Future of the conda community and these calls
+
+
+### Outstanding Items From the Previous Meeting
+
+
+### Active Votes
+
+
+### Subteam Updates
+
+
+### Open PRs
+
+
+## Discussion
+
+
+## Action items
+
+
+## Last meeting points (2020-05-25)

--- a/meetings/archive/20210707_agenda_and_minutes.md
+++ b/meetings/archive/20210707_agenda_and_minutes.md
@@ -1,0 +1,75 @@
+# 2021-07-07 Conda Community Meeting
+
+* [Meeting link](https://meet.google.com/owq-kbca-abk)
+* [What time is the meeting in my time zone](https://arewemeetingyet.com/Chicago/2021-07-07/12:00/b/Conda%20community%20meeting)
+* [Last Meeting's Agenda and Minutes](https://github.com/conda-incubator/governance/tree/master/meetings)
+
+
+## Attendees
+
+| Name               | Initials | Affiliation   | GH Username     |
+| ------------------ | -------- |-------------- | --------------- |
+| Cheng H. Lee       | CHL      | Anaconda      | @chenghlee      |
+| Jannis Leidel      | JL       | Anaconda      | @jezdez         |
+| Marcel Bargull     | MB       | Bioconda/cf   | @mbargull       |
+| Filipe Fernandes   | FF       | conda-forge   | @ocefpaf        |
+| Sebastien Awwad    | SA       | Anaconda      | @awwad          |
+| Matt B             | MRB      | cf            |  @beckermr      |
+| Jaime RG           | JRG      | Quansight     |  @jaimergp      |
+| John Lee           | JL       | Quansight     |  @leej3         |
+| Julio Batista      | JBS      |               |  @jbsilva       |
+
+
+### Introductions
+
+* Julio Batista
+
+
+### Announcements
+
+* conda 4.10.3 released; available on defaults and conda-forge
+* [Conda Enhancement Proposals](https://github.com/conda/ceps) relaunch
+* menuinst, pycosat repositories moving to conda org
+    * Please feel free to ping Jannis or Cheng if another (ContinuumIO/Anaconda) repo needs to be moved
+
+
+### Standing Items
+
+* Conda Community website mockups
+* Outreach to invite more organizations to join this meeting
+
+
+### New Agenda Items
+
+* CEPs:
+    * Should we apply [governance voting rules](https://github.com/conda-incubator/governance) from?
+    * Clarify whether which CEPs apply to `conda` the application and which apply to `conda` the ecosystem
+    * (TODO) CEP for artifact signature verification (SA, next two weeks)
+* RHEL 8 OpenSSL
+    * defaults and conda-forge OpenSSL packages do include RHEL OpenSSL patches, which causes problems with system applications
+        * E.g., https://github.com/conda/conda/issues/10241
+    * Broader discussion --- how do we deal with:
+        * compatiblity with (patched) system libraries;
+        * system executables picking up conda libraries
+    * (TODO) convo on if this is going to be fixed on RedHat side, etc.  (CW? JL?)
+
+
+### Outstanding Items From the Previous Meeting
+
+
+### Active Votes
+
+
+### Subteam Updates
+
+
+### Open PRs
+
+
+## Discussion
+
+
+## Action items
+
+
+## Last meeting points


### PR DESCRIPTION
There was a gap in the archived meeting notes, so I browsed the Slack server for hackmd.io links.  This is all I found, which leaves the `archive` like this:

```
20200721_agenda_and_minutes.md
20200824_agenda_and_minutes.md
20200908_agenda_and_minutes.md
20200922_agenda_and_minutes.md
20201006_agenda_and_minutes.md
20201020_agenda_and_minutes.md
20201102_agenda_and_minutes.md
20201117_agenda_and_minutes.md
20201201_agenda_and_minutes.md
20201215_agenda_and_minutes.md
20210112_agenda_and_minutes.md
20210126_agenda_and_minutes.md
20210303_agenda_and_minutes.md
20210317_agenda_and_minutes.md
20210331_agenda_and_minutes.md
20210414_agenda_and_minutes.md
20210428_agenda_and_minutes.md
20210511_agenda_and_minutes.md
20210525_agenda_and_minutes.md
20210623_agenda_and_minutes.md
20210707_agenda_and_minutes.md
20210721_agenda_and_minutes.md
```

I can see there're some (expected) dates missing, but I don't know if the meeting didn't happen then or no notes were taken:

* 2021 February had no meetings
* 2021 June had only one meeting, but I think one of them was canceled because it conflicted with Anaconda Con?