### PR TITLE
Move kkraus14 back to steering council. update funding status

### DIFF
--- a/emeritus.csv
+++ b/emeritus.csv
@@ -7,7 +7,6 @@ angloyna,angela.gloyna@gmail.com,Angela Gloyna
 jjhelmus,jjhelmus@gmail.com,Jonathan Helmus
 prusse-martin,prusse.martin@gmail.com,Martin Prüsse
 myancy-anaconda,myancy@anaconda.com,Megan Yancy
-kkraus14,keith.j.kraus@gmail.com,Keith Kraus
 teoliphant,teoliphant@gmail.com,Travis Oliphant
 dharhas,dharhas@gmail.com,Dharhas Pothina
 cjmartian,connormartin7@gmail.com,Connor Martin

--- a/steering.csv
+++ b/steering.csv
@@ -14,3 +14,4 @@ beckermr,becker.mr@gmail.com,Matthew R. Becker,no funding,he/him
 jezdez,jannis@leidel.info,Jannis Leidel,Anaconda,he/him
 wolfv,w.vollprecht@gmail.com,Wolf Vollprecht,,
 jaimergp,jaime.rogue@gmail.com,Jaime Rodríguez-Guerra,Quansight,he/him
+kkraus14,keith.j.kraus@gmail.com,Keith Kraus,no funding, he/him


### PR DESCRIPTION
According to our new governance docs, 

> Nominated members will provide a list of organizations that fund above 25% of their time. 
...
> In cases where people have absolutely no funding related to conda, we still document this funding state, but we do not require people to list their irrelevant funding. The "no funding" state can be held by an unlimited number of Steering Council members.
> What about cases where someone works on conda for work they are doing, but improving/directing the conda ecosystem is not a specific component of any of their funding? Generally, such cases should be considered as "no funding."

While the three of us (@kkraus14, @mariusvniekerk, and myself) work at Voltron Data, we are not funded to work on or participate in the conda ecosystem. According to our docs this puts all of us in a "no funding" status. Therefore it is irrelevant that the three of us work at Voltron Data and Keith should not have been forced to move to emeritus.