### PR TITLE
Fix outputs in meeting notes workflow.

### DIFF
--- a/.github/workflows/meeting-notes.yml
+++ b/.github/workflows/meeting-notes.yml
@@ -29,8 +29,8 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name != 'pull_request'
     outputs:
-      should-run: ${{ steps.return-value.should-run }}
-      date: ${{ steps.return-value.date }}
+      should-run: ${{ steps.return-value.outputs.should-run }}
+      date: ${{ steps.return-value.outputs.date }}
     steps:
       - name: Setup Python
         if: github.event_name == 'schedule'

--- a/.github/workflows/meeting-notes.yml
+++ b/.github/workflows/meeting-notes.yml
@@ -78,10 +78,10 @@ jobs:
 
   create:
     needs: [pre-create]
-    if: pre-create.outputs.should-run == 'yes'
+    if: needs.pre-create.outputs.should-run == 'yes'
     uses: Quansight-Labs/hackmd-meeting-notes-action/.github/workflows/create-meeting-notes-pr.yml@main
     with:
-      date: ${{ pre-create.outputs.date }}
+      date: ${{ needs.pre-create.outputs.date }}
       template_path: meetings/agenda_template.md
       output_path: meetings/archive/%Y%m%d_agenda_and_minutes.md
       hackmd_team: conda-community


### PR DESCRIPTION
According to https://docs.github.com/en/actions/using-jobs/defining-outputs-for-jobs and https://docs.github.com/en/actions/learn-github-actions/contexts#example-usage-of-the-needs-context using `outputs` and `needs..` is needed