### PR TITLE
Add lrandersson to constructor team

### DIFF
--- a/teams/constructor.yml
+++ b/teams/constructor.yml
@@ -23,6 +23,7 @@ members:
   jaimergp: https://github.com/conda/governance/issues/53
   jezdez: https://github.com/conda/governance/issues/53
   larsoner: https://github.com/conda/governance/issues/53
+  lrandersson: https://github.com/conda/governance/issues/332
   marcoesters: # missing record of decision?
   mcg1969: https://github.com/conda/governance/issues/53 # missing from team?
   pseudoyim: https://github.com/conda/governance/issues/53


### PR DESCRIPTION
## Summary

- Adds @lrandersson to the constructor team
- Part of the installers team at Anaconda, will assist with review and maintenance

## References

Closes #332